### PR TITLE
Add Linux support

### DIFF
--- a/src/main/java/xyz/rive/jttplayer/util/FxUtils.java
+++ b/src/main/java/xyz/rive/jttplayer/util/FxUtils.java
@@ -404,6 +404,10 @@ public final class FxUtils {
         return isOS("mac");
     }
 
+    public static boolean isLinux() {
+        return isOS("linux");
+    }
+
     public static boolean isMouseHover(PopMenu menu, double screenX, double screenY) {
         double x = menu.getX();
         double y = menu.getY();
@@ -430,8 +434,10 @@ public final class FxUtils {
                     "/select,",
                     "\"" + detransformPath(url) + "\""
             };
+        } else if(isLinux()) {
+            cmdArray = new String[] { "xdg-open", transformPath(url) };
         }
-        //Linux Unsupported / Unknown
+        // Linux is now supported
         if(cmdArray != null) {
             runExec(cmdArray);
         }

--- a/src/main/java/xyz/rive/jttplayer/util/StringUtils.java
+++ b/src/main/java/xyz/rive/jttplayer/util/StringUtils.java
@@ -162,7 +162,9 @@ public final class StringUtils {
         String dataRoot = "Library/Application Support";
         if(isWindows()) {
             dataRoot = "AppData/Roaming";
-        } else if(!isMacOS()) {
+        } else if(isLinux()) {
+            dataRoot = ".config";
+        } else {
             dataRoot = "Documents";
         }
         return String.format("%1$s/%2$s/jTTPlayer",


### PR DESCRIPTION
- Add `isLinux()` detection method in `FxUtils`
- Add Linux support for `showInFolder()` using `xdg-open`
- Use `~/.config/jTTPlayer` for Linux app data directory (XDG spec compliant)

Used `liberica-jdk8-fx` to compile, as following:

```bash
cd /tmp
wget https://download.bell-sw.com/java/8u462+11/bellsoft-jdk8u462+11-linux-amd64-full.tar.gz
tar -xzvf bellsoft-jdk8u462+11-linux-amd64-full.tar.gz
sudo mv jdk8u462-full/ /opt/liberica-jdk8-fx
cd ~/projects/jTTPlayer
JAVA_HOME=/opt/liberica-jdk8-fx/ ./gradlew compileJava
```

To start, run this:

```bash
GDK_BACKEND=x11 /opt/liberica-jdk8-fx/jre/bin/java -Xbootclasspath/a:"/opt/liberica-jdk8-fx/jre/lib/ext/jfxrt.jar" -cp "build/libs/jTTPlayer.jar:$(find ~/.gradle/caches/modules-2/files-2.1 -name '*.jar' ! -name '*-javadoc.jar' ! -name '*-sources.jar' | tr '\n' ':')" xyz.rive.jttplayer.MainApplication 
```

<img width="464" height="233" alt="1FE9095EF290579E57EC0761412824CA" src="https://github.com/user-attachments/assets/d96c103e-2b27-4b78-a26d-61910a606dad" />

Issues known and planned to solve:

- No actual voice output. (XDG incapable?)
- Incapable with Wayland, can only run at X11. (Java 8's incapable with wayland)
- UI Error (Also Java 8's issue)